### PR TITLE
Refactor: Rename HandleAsync to Handle in endpoints

### DIFF
--- a/example/ExampleApi/Endpoints/Todos/Delete/DeleteTodoEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/Delete/DeleteTodoEndpoint.cs
@@ -24,7 +24,7 @@ public class DeleteTodoEndpoint : IEndpointWithoutResponse<RequestModel>
 			.Version(1.0);
 	}
 
-	public async Task HandleAsync(RequestModel request, CancellationToken ct)
+	public async Task Handle(RequestModel request, CancellationToken ct)
 	{
 		await _todoStore.DeleteAsync(request.Id, ct);
 	}

--- a/example/ExampleApi/Endpoints/Todos/GetAll/GetAllTodosEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/GetAll/GetAllTodosEndpoint.cs
@@ -24,7 +24,7 @@ public class GetAllTodosEndpoint : IEndpointWithoutRequest<ResponseModel[]>
 			.Version(1.0);
 	}
 
-	public async Task<ResponseModel[]> HandleAsync(CancellationToken ct)
+	public async Task<ResponseModel[]> Handle(CancellationToken ct)
 	{
 		IEnumerable<Todo> result = await _todoStore.GetAllAsync(ct);
 

--- a/example/ExampleApi/Endpoints/Todos/GetById/GetTodoByIdEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/GetById/GetTodoByIdEndpoint.cs
@@ -25,7 +25,7 @@ public class GetTodoByIdEndpoint : IEndpoint<RequestModel, ResponseModel?>
 			.Version(1.0);
 	}
 
-	public async Task<ResponseModel?> HandleAsync(RequestModel request, CancellationToken ct)
+	public async Task<ResponseModel?> Handle(RequestModel request, CancellationToken ct)
 	{
 		Todo? result = await _todoStore.GetByIdAsync(request.Id, ct);
 

--- a/example/ExampleApi/Endpoints/Todos/GetExport/GetExportEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/GetExport/GetExportEndpoint.cs
@@ -28,7 +28,7 @@ public class GetExportEndpoint : IEndpointWithoutRequest<Results<FileContentHttp
 			.Version(1.0);
 	}
 
-	public async Task<Results<FileContentHttpResult, NoContent>> HandleAsync(CancellationToken ct)
+	public async Task<Results<FileContentHttpResult, NoContent>> Handle(CancellationToken ct)
 	{
 		IEnumerable<Todo> result = await _todoStore.GetAllAsync(ct);
 

--- a/example/ExampleApi/Endpoints/Todos/Patch/PatchTodoEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/Patch/PatchTodoEndpoint.cs
@@ -25,7 +25,7 @@ public class PatchTodoEndpoint : IEndpoint<RequestModel, ResponseModel?>
 			.Version(1.0);
 	}
 
-	public async Task<ResponseModel?> HandleAsync(RequestModel request, CancellationToken ct)
+	public async Task<ResponseModel?> Handle(RequestModel request, CancellationToken ct)
 	{
 		Todo? updatedTodo = await _todoStore.PatchAsync(request.Id, todo =>
 		{

--- a/example/ExampleApi/Endpoints/Todos/PostDataAnnotation/PostTodoEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/PostDataAnnotation/PostTodoEndpoint.cs
@@ -26,7 +26,7 @@ public class PostTodoEndpoint : IEndpoint<RequestModel, Results<Ok<ResponseModel
 			.Version(1.0);
 	}
 
-	public async Task<Results<Ok<ResponseModel>, Conflict>> HandleAsync(RequestModel request, CancellationToken ct)
+	public async Task<Results<Ok<ResponseModel>, Conflict>> Handle(RequestModel request, CancellationToken ct)
 	{
 		if ((await _todoStore.GetAllAsync(ct)).Any(x => x.Title.Equals(request.Title, StringComparison.InvariantCultureIgnoreCase)))
 		{

--- a/example/ExampleApi/Endpoints/Todos/PostFluentValidation/PostTodoEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/PostFluentValidation/PostTodoEndpoint.cs
@@ -26,7 +26,7 @@ public class PostTodoEndpoint : IEndpoint<RequestModel, Results<Ok<ResponseModel
 			.Version(1.0);
 	}
 
-	public async Task<Results<Ok<ResponseModel>, Conflict>> HandleAsync(RequestModel request, CancellationToken ct)
+	public async Task<Results<Ok<ResponseModel>, Conflict>> Handle(RequestModel request, CancellationToken ct)
 	{
 		if ((await _todoStore.GetAllAsync(ct)).Any(x => x.Title.Equals(request.Title, StringComparison.InvariantCultureIgnoreCase)))
 		{

--- a/example/ExampleApi/Endpoints/Todos/Put/PutTodoEndpoint.cs
+++ b/example/ExampleApi/Endpoints/Todos/Put/PutTodoEndpoint.cs
@@ -25,7 +25,7 @@ public class PutTodoEndpoint : IEndpoint<RequestModel, ResponseModel?>
 			.Version(1.0);
 	}
 
-	public async Task<ResponseModel?> HandleAsync(RequestModel request, CancellationToken ct)
+	public async Task<ResponseModel?> Handle(RequestModel request, CancellationToken ct)
 	{
 		Todo todo = new()
 		{

--- a/example/ExampleApi/Endpoints/WeatherForecast/Get/V1/GetWeatherForecastEndpoint.cs
+++ b/example/ExampleApi/Endpoints/WeatherForecast/Get/V1/GetWeatherForecastEndpoint.cs
@@ -17,7 +17,7 @@ public class GetWeatherForecastEndpoint : IEndpointWithoutRequest<ResponseModel[
 		"Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 	];
 
-	public async Task<ResponseModel[]> HandleAsync(CancellationToken ct)
+	public async Task<ResponseModel[]> Handle(CancellationToken ct)
 	{
 		ResponseModel[] forecast = [.. Enumerable.Range(1, 5).Select(index =>
 			new ResponseModel

--- a/example/ExampleApi/Endpoints/WeatherForecast/Get/V2/GetWeatherForecastEndpoint.cs
+++ b/example/ExampleApi/Endpoints/WeatherForecast/Get/V2/GetWeatherForecastEndpoint.cs
@@ -19,7 +19,7 @@ public class GetWeatherForecastEndpoint : IEndpointWithoutRequest<ResponseModel[
 		"Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
 	];
 
-	public async Task<ResponseModel[]> HandleAsync(CancellationToken ct)
+	public async Task<ResponseModel[]> Handle(CancellationToken ct)
 	{
 		ResponseModel[] forecast = [.. Enumerable.Range(1, 5).Select(index =>
 			new ResponseModel

--- a/src/IeuanWalker.MinimalApi.Endpoints.Generator/Helpers/EndpointGeneratorHelper.cs
+++ b/src/IeuanWalker.MinimalApi.Endpoints.Generator/Helpers/EndpointGeneratorHelper.cs
@@ -19,7 +19,7 @@ static class EndpointGeneratorHelper
 			builder.AppendLine($"{endpoint.GetBindingType()}global::{endpoint.RequestType} request,");
 		}
 		builder.AppendLine($"[FromServices] global::{endpoint.ClassName} endpoint,");
-		builder.Append($"CancellationToken ct) => await endpoint.HandleAsync({(endpoint.HasRequest ? "request, " : string.Empty)}ct))");
+		builder.Append($"CancellationToken ct) => await endpoint.Handle({(endpoint.HasRequest ? "request, " : string.Empty)}ct))");
 
 		builder.DecreaseIndent();
 

--- a/src/IeuanWalker.MinimalApi.Endpoints/IEndpoint.cs
+++ b/src/IeuanWalker.MinimalApi.Endpoints/IEndpoint.cs
@@ -9,20 +9,20 @@ public interface IEndpointBase
 
 public interface IEndpoint : IEndpointBase
 {
-	Task HandleAsync(CancellationToken ct);
+	Task Handle(CancellationToken ct);
 }
 
 public interface IEndpoint<in TRequest, TResponse> : IEndpointBase
 {
-	Task<TResponse> HandleAsync(TRequest request, CancellationToken ct);
+	Task<TResponse> Handle(TRequest request, CancellationToken ct);
 }
 
 public interface IEndpointWithoutRequest<TResponse> : IEndpointBase
 {
-	Task<TResponse> HandleAsync(CancellationToken ct);
+	Task<TResponse> Handle(CancellationToken ct);
 }
 
 public interface IEndpointWithoutResponse<in TRequest> : IEndpointBase
 {
-	Task HandleAsync(TRequest request, CancellationToken ct);
+	Task Handle(TRequest request, CancellationToken ct);
 }


### PR DESCRIPTION
Standardized method naming by renaming `HandleAsync` to `Handle` across all endpoint classes, including `DeleteTodoEndpoint`, `GetAllTodosEndpoint`, `GetTodoByIdEndpoint`, `GetExportEndpoint`, `PatchTodoEndpoint`, `PostTodoEndpoint`, `PutTodoEndpoint`, and `GetWeatherForecastEndpoint`.

Updated `EndpointGeneratorHelper` to generate calls to `Handle` instead of `HandleAsync`.

Modified `IEndpoint` and its derived interfaces in `IEndpoint.cs` to reflect the method name change:
- `IEndpoint` now defines `Task Handle(CancellationToken ct)`.
- `IEndpoint<TRequest, TResponse>` now defines `Task<TResponse> Handle(TRequest request, CancellationToken ct)`.
- `IEndpointWithoutRequest<TResponse>` now defines `Task<TResponse> Handle(CancellationToken ct)`.
- `IEndpointWithoutResponse<TRequest>` now defines `Task Handle(TRequest request, CancellationToken ct)`.

These changes improve consistency and align with the desired naming conventions while preserving functionality.