### PR TITLE
Fix: enable caching for authenticated responses in ServeResponseAsync

### DIFF
--- a/src/IeuanWalker.MinimalApi.Endpoints/AllowAuthenticatedCachePolicy.cs
+++ b/src/IeuanWalker.MinimalApi.Endpoints/AllowAuthenticatedCachePolicy.cs
@@ -42,6 +42,11 @@ sealed class AllowAuthenticatedCachePolicy : IOutputCachePolicy
 			return ValueTask.CompletedTask;
 		}
 
+		// Re-enable storage that the built-in DefaultPolicy disables for authenticated
+		// requests in its own ServeResponseAsync. Without this, authenticated responses
+		// are never stored and this policy has no effect.
+		context.AllowCacheStorage = true;
+
 		return ValueTask.CompletedTask;
 	}
 }

--- a/src/IeuanWalker.MinimalApi.Endpoints/Extensions/ETagExtensions.cs
+++ b/src/IeuanWalker.MinimalApi.Endpoints/Extensions/ETagExtensions.cs
@@ -1,0 +1,22 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace IeuanWalker.MinimalApi.Endpoints.Extensions;
+
+/// <summary>
+/// Extension methods for generating ETags for output cache revalidation.
+/// </summary>
+public static class ETagExtensions
+{
+	/// <summary>
+	/// Generates a deterministic ETag based on the serialized object content using SHA256.
+	/// Useful for output caching with cache revalidation (If-None-Match → 304 Not Modified).
+	/// </summary>
+	public static string GenerateEtag<T>(this T obj)
+	{
+		string jsonContent = JsonSerializer.Serialize(obj);
+		byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(jsonContent));
+		return $"\"{Convert.ToHexString(hash)}\"";
+	}
+}


### PR DESCRIPTION
The AllowAuthenticatedCachePolicy now correctly re-enables AllowCacheStorage in ServeResponseAsync to override the built-in DefaultPolicy which disables it for authenticated requests. This ensures authenticated responses are actually cached when using output caching with ETags/cache revalidation.

Before this fix, the policy was effectively a no-op - responses were never cached. This fix enables the intended feature: safe authenticated response caching with proper guards (no Set-Cookie, 200-only status).

See: https://github.com/IeuanWalker/MinimalApi.Endpoints/issues/XXX